### PR TITLE
Add error handling, resource management and ignored variables to mdo

### DIFF
--- a/tests/either-tests.lisp
+++ b/tests/either-tests.lisp
@@ -18,6 +18,6 @@
   (testing "flatmap flattens the result of applying a function to the value in a right"
     (let ((fun (lambda (x) (right (+ x 1)))))
       (ok (equalp (monad:flatmap fun (right 10)) (right 11))))
-    (let ((fun (lambda (x) (left "an error"))))
+    (let ((fun (lambda (x) (declare (ignore x)) (left "an error"))))
       (ok (equalp (monad:flatmap fun (right 10)) (left "an error"))))))
 


### PR DESCRIPTION
Adds new `with` clause that calls the specified tidy up function in an unwind protect to ensure resources are cleaned up.

Adds handle clauses which handles errors of the specified type in subsequent clauses and returns the specified value.

Adds `_` as a by default ignored variable.