### PR TITLE
Add clean on error clause

### DIFF
--- a/src/monad.lisp
+++ b/src/monad.lisp
@@ -42,7 +42,6 @@
              (if (not seen-unwrap)
                  (progn (setf seen-unwrap t)
                         `(fmap (lambda (,(caddr clause)) 
-                                 ,@(ignore-underscore (caddr clause))
                                  (handler-case 
                                      ,acc
                                    (error (,e)
@@ -50,7 +49,6 @@
                                      (error ,e))))
                                (progn ,@(cdddr clause))))
                  `(flatmap (lambda (,(caddr clause))
-                             ,@(ignore-underscore (caddr clause))
                              (handler-case
                                  ,acc
                                (error (,e) 

--- a/src/monad.lisp
+++ b/src/monad.lisp
@@ -31,12 +31,32 @@
                                    ,acc
                                 (funcall ,(cadr clause) ,(caddr clause))))
                             (progn ,@(cdddr clause))))
-               (progn `(flatmap (lambda (,(caddr clause))
+               `(flatmap (lambda (,(caddr clause))
                                   ,@(ignore-underscore (caddr clause))
                             (unwind-protect
                                  ,acc
                               (funcall ,(cadr clause) ,(caddr clause))))
-                          (progn ,@(cdddr clause))))))
+                          (progn ,@(cdddr clause)))))
+          ((equal (symbol-name (car clause)) (symbol-name 'clean-on-error))
+           (let ((e (gensym)))
+             (if (not seen-unwrap)
+                 (progn (setf seen-unwrap t)
+                        `(fmap (lambda (,(caddr clause)) 
+                                 ,@(ignore-underscore (caddr clause))
+                                 (handler-case 
+                                     ,acc
+                                   (error (,e)
+                                     (funcall ,(cadr clause) ,(caddr clause))
+                                     (error ,e))))
+                               (progn ,@(cdddr clause))))
+                 `(flatmap (lambda (,(caddr clause))
+                             ,@(ignore-underscore (caddr clause))
+                             (handler-case
+                                 ,acc
+                               (error (,e) 
+                                 (funcall ,(cadr clause) ,(caddr clause))
+                                 (error ,e))))
+                           (progn ,@(cdddr clause))))))
           ((not seen-unwrap)
            (setf seen-unwrap t)
            `(fmap (lambda (,(car clause)) 


### PR DESCRIPTION
Add clean-on-error clause which only calls the cleanup function for a resource if an error occurs in the body of mdo.

This is useful for resources that need to be cleaned up but have extent beyond the scope of the mdo in which they occur.