### PR TITLE
Fix bug in list flatmap

### DIFF
--- a/src/mlist.lisp
+++ b/src/mlist.lisp
@@ -7,4 +7,4 @@
   (mapcar fun l))
 
 (defmethod flatmap (fun (l list))
-  (mapcan fun l))
+  (apply #'append (mapcar fun l)))


### PR DESCRIPTION
Fix bug where optimization of flatmap could lead to accidental modification of shared structure if the flatmapped function didn't return a new list.