### PR TITLE
Use `:constructor` and `:conc-name` to simplify code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,14 @@ jobs:
           wget https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh
           chmod +x ./install-for-ci.sh
           ./install-for-ci.sh          
+
+      - name: Download dissect
+        run: |
+          wget -q -O- https://dist.shirakumo.org/archives/dissect/dissect-a70cabcd748cf7c041196efd711e2dcca2bbbb2c.tgz | tar -xz -C ~/.roswell/local-projects
+
       - name: Install Rove
         run: ros install rove
+
       - name: Run tests      
         run: |
           PATH="~/.roswell/bin:$PATH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         lisp: [sbcl-bin, ccl-bin]
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v1

--- a/src/either.lisp
+++ b/src/either.lisp
@@ -1,32 +1,29 @@
 (defpackage :either
   (:use :cl :monad)
   (:import-from :monad :fmap :flatmap)
-  (:export :right :left :right-value :left-err :if-absent))
+  (:export :right :left :value :err :if-absent))
 
 (in-package :either)
 
-(defstruct left err)
-(defstruct right value)
-
-(defun left (e) (make-left :err e))
-(defun right (v) (make-right :value v))
+(defstruct (left (:constructor left (err)) (:conc-name)) err)
+(defstruct (right (:constructor right (value)) (:conc-name)) value)
 
 (defun if-absent (v err) (or (and v (right v)) (left err)))
 
 (defmethod print-object ((left left) out)
   (print-unreadable-object (left out :type t)
-    (format out "~a" (left-err left))))
+    (format out "~a" (err left))))
 
 (defmethod print-object ((right right) out)
   (print-unreadable-object (right out :type t)
-    (format out "~a" (right-value right))))
+    (format out "~a" (value right))))
 
 (defmethod fmap (fun (left left)) left)
 
 (defmethod fmap (fun (right right))
-  (right (funcall fun (right-value right))))
+  (right (funcall fun (value right))))
 
 (defmethod flatmap (fun (left left)) left)
 
 (defmethod flatmap (fun (right right))
-  (funcall fun (right-value right)))
+  (funcall fun (value right)))

--- a/src/maybe.lisp
+++ b/src/maybe.lisp
@@ -1,25 +1,23 @@
 (defpackage :maybe
   (:use :cl :monad)
   (:import-from :monad :fmap :flatmap)
-  (:export :just-value
+  (:export :value
            :just))
 
 (in-package :maybe)
 
-(defstruct just value)
-
-(defun just (v) (make-just :value v))
+(defstruct (just (:constructor just (value)) (:conc-name)) value)
 
 (defmethod print-object ((just just) out)
   (print-unreadable-object (just out :type t)
-    (format out "~a" (just-value just))))
+    (format out "~a" (value just))))
 
 (defmethod fmap (fun (v (eql nil))) v)
 
 (defmethod fmap (fun (just just))
-  (just (funcall fun (just-value just))))
+  (just (funcall fun (value just))))
 
 (defmethod flatmap (fun (v (eql nil))) v)
 
 (defmethod flatmap (fun (just just))
-  (funcall fun (just-value just)))
+  (funcall fun (value just)))

--- a/tests/maybe-tests.lisp
+++ b/tests/maybe-tests.lisp
@@ -5,11 +5,11 @@
 
 (deftest just-test 
     (testing "just-value is inverse of just"
-      (ok (= (just-value (just 10)) 10))))
+      (ok (= (value (just 10)) 10))))
 
 (deftest fmaptest
     (testing "fmap action on just and nothing"
-      (ok (= (just-value (monad:fmap (lambda (x) (+ x 1)) (just 10)))
+      (ok (= (value (monad:fmap (lambda (x) (+ x 1)) (just 10)))
              11)
           "fmap applies a function to the value in just")
       (ok (eq (monad:fmap (lambda (x) (+ x 1)) nil) nil)
@@ -17,9 +17,9 @@
 
 (deftest flatmap-test
     (testing "flatmap action on just and nothing"
-      (ok (typep (just-value (monad:flatmap #'just (just 10))) 'integer)
+      (ok (typep (value (monad:flatmap #'just (just 10))) 'integer)
           "flatmap does not nest just")
-      (ok (= (just-value (monad:flatmap (lambda (x) (just (+ x 1))) (just 10))) 11)
+      (ok (= (value (monad:flatmap (lambda (x) (just (+ x 1))) (just 10))) 11)
           "flatmap applies a function to the value of just")
       (ok (eq (monad:flatmap (lambda (x) (+ x 1)) nil) nil)
           "flatmap leaves nil as nil")))


### PR DESCRIPTION
Uses `:constructor` and `:conc-name` in struct definitions to simplify monad instances.

Related to https://github.com/HenryS1/salmon/issues/8